### PR TITLE
fix bas58 encoding of uint256 with leading zeros

### DIFF
--- a/AddressUtil/Base58.cpp
+++ b/AddressUtil/Base58.cpp
@@ -71,7 +71,8 @@ std::string Base58::toBase58(const secp256k1::uint256 &x)
 
 	secp256k1::uint256 value = x;
 
-	while(!value.isZero()) {
+	//while(!value.isZero()) {
+	for(unsigned int i=0; i<=32; i++){
 		secp256k1::uint256 digit = value.mod(58);
 		int digitInt = digit.toInt32();
 


### PR DESCRIPTION
When the input to base58 starts with leading zeros, this function will return a bad result.
This PR fixes this issue.